### PR TITLE
Auto restart the generators if they fail.

### DIFF
--- a/workshops/dash-observability-pipelines/systemd/storedog-gen.service
+++ b/workshops/dash-observability-pipelines/systemd/storedog-gen.service
@@ -3,6 +3,7 @@ Description=Generates synthetic logs from an HTTP service.
 
 [Service]
 ExecStart=/root/lab/bin/storedog-gen
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/workshops/dash-observability-pipelines/systemd/vpc-gen.service
+++ b/workshops/dash-observability-pipelines/systemd/vpc-gen.service
@@ -3,6 +3,7 @@ Description=Generates synthetic traffic like AWS' VPC flow logs.
 
 [Service]
 ExecStart=/root/lab/bin/vpc-gen
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We had some problems in the in-person lab with the storedog generators dying due to a panic. This should help with not disrupting the attendees' experience.