### PR TITLE
Add quotes docker compose

### DIFF
--- a/courses/service-catalog/docker-compose.yml
+++ b/courses/service-catalog/docker-compose.yml
@@ -22,14 +22,14 @@ services:
       - "8126:8126/tcp"
       - "8125:8125/udp"
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "/proc/:/host/proc/:ro"
-      - "/sys/fs/cgroup/:/host/sys/fs/cgroup:ro"
-      - "/sys/kernel/debug:/sys/kernel/debug"
-      - "/:/host/root:ro"
-      - "/etc/passwd:/etc/passwd:ro"
-      - "/etc/group:/etc/group:ro"
-      - "/etc/os-release:/etc/os-release"
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+      - /sys/kernel/debug:/sys/kernel/debug
+      - /:/host/root:ro
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
+      - /etc/os-release:/etc/os-release
     cap_add:
       - SYS_ADMIN
       - SYS_RESOURCE
@@ -72,7 +72,7 @@ services:
     image: public.ecr.aws/x2b9z2t7/storedog/frontend:1.0.8
     command: bash -c "yarn upgrade @datadog/browser-rum && yarn dev"
     volumes:
-      - "/root/lab/.env:/storedog-app/site/.env.local"
+      - /root/lab/.env:/storedog-app/site/.env.local
     ports:
       - "${FRONTEND_PORT-3000}:${FRONTEND_PORT-3000}"
     environment:
@@ -109,8 +109,8 @@ services:
     ports:
       - ${ADMIN_PORT:-4000}:${ADMIN_PORT:-4000}
     volumes:
-      - "/root/rails_database.yml:/app/config/database.yml"
-      - "/root/services/backend/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb"
+      - /root/rails_database.yml:/app/config/database.yml
+      - /root/services/backend/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb
     environment:
       - REDIS_URL
       - DB_HOST=db
@@ -143,8 +143,8 @@ services:
       - backend
       - datadog
     volumes:
-      - "/root/rails_database.yml:/app/config/database.yml"
-      - "/root/services/worker/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb"
+      - /root/rails_database.yml:/app/config/database.yml
+      - /root/services/worker/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb
     environment:
       - REDIS_URL
       - DB_HOST=db
@@ -204,8 +204,8 @@ services:
       - datadog
       - frontend
     volumes:
-      - "/root/nginx_default.conf:/etc/nginx/conf.d/default.conf"
-      - "/root/nginx_status.conf:/etc/nginx/conf.d/status.conf"
+      - /root/nginx_default.conf:/etc/nginx/conf.d/default.conf
+      - /root/nginx_status.conf:/etc/nginx/conf.d/status.conf
     labels:
       com.datadog.tags.env: '${DD_ENV}'
       com.datadog.tags.service: 'store-nginx'
@@ -232,11 +232,11 @@ services:
       com.datadoghq.ad.instances: '[{"host":"%%host%%", "port":5432,"username":"datadog","password":"datadog"}]'
       com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "postgres"}]'
     volumes:
-      - "/root/restore.sql:/docker-entrypoint-initdb.d/restore.sql"
+      - /root/restore.sql:/docker-entrypoint-initdb.d/restore.sql
   redis:
     image: redis:6.2-alpine
     volumes:
-      - "/root/redis:/data"
+      - /root/redis:/data
     labels:
       com.datadoghq.tags.env: '${DD_ENV}'
       com.datadoghq.tags.service: 'redis'
@@ -269,8 +269,8 @@ services:
   puppeteer:
     image: buildkite/puppeteer:10.0.0
     volumes:
-      - "/root/puppeteer.js:/puppeteer.js"
-      - "/root/puppeteer.sh:/puppeteer.sh"
+      - /root/puppeteer.js:/puppeteer.js
+      - /root/puppeteer.sh:/puppeteer.sh
     environment:
       - STOREDOG_URL
       - PUPPETEER_TIMEOUT

--- a/courses/service-catalog/docker-compose.yml
+++ b/courses/service-catalog/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 services:
   datadog:
     image: gcr.io/datadoghq/agent:7
@@ -19,8 +19,8 @@ services:
       - HOST_ROOT='/host/root'
     pid: host
     ports:
-      - 8126:8126/tcp
-      - 8125:8125/udp
+      - "8126:8126/tcp"
+      - "8125:8125/udp"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc/:/host/proc/:ro
@@ -58,7 +58,7 @@ services:
       - DD_PROFILING_ENABLED=true
       - DD_APPSEC_ENABLED=true
     ports:
-      - ${DISCOUNTS_PORT}:${DISCOUNTS_PORT}
+      - "${DISCOUNTS_PORT}:${DISCOUNTS_PORT}"
     depends_on:
       - datadog
       - db
@@ -74,7 +74,7 @@ services:
     volumes:
       - /root/lab/.env:/storedog-app/site/.env.local
     ports:
-      - ${FRONTEND_PORT-3000}:${FRONTEND_PORT-3000}
+      - "${FRONTEND_PORT-3000}:${FRONTEND_PORT-3000}"
     environment:
       - DD_AGENT_HOST=datadog
       - DD_LOGS_INJECTION=true
@@ -185,7 +185,7 @@ services:
       - DD_PROFILING_ENABLED=true
       - DD_APPSEC_ENABLED=true
     ports:
-      - ${ADS_PORT}:${ADS_PORT}
+      - "${ADS_PORT}:${ADS_PORT}"
     depends_on:
       - datadog
       - db
@@ -199,7 +199,7 @@ services:
     image: nginx:1.21.4
     restart: always
     ports:
-      - 80:80
+      - "80:80"
     depends_on:
       - frontend
     volumes:
@@ -220,7 +220,7 @@ services:
       - POSTGRES_PASSWORD
       - POSTGRES_USER
     ports:
-      - 5432:5432
+      - "5432:5432"
     labels:
       com.datadoghq.tags.env: '${DD_ENV}'
       com.datadoghq.tags.service: 'database'
@@ -256,7 +256,7 @@ services:
       - DD_PROFILING_ENABLED=true
       - DD_APPSEC_ENABLED=true
     ports:
-      - 8000:8000
+      - "8000:8000"
     depends_on:
       - datadog
     labels:

--- a/courses/service-catalog/docker-compose.yml
+++ b/courses/service-catalog/docker-compose.yml
@@ -73,8 +73,8 @@ services:
     command: bash -c "yarn upgrade @datadog/browser-rum && yarn dev"
     volumes:
       - "/root/lab/.env:/storedog-app/site/.env.local"
-    ports:
-      - "${FRONTEND_PORT-3000}:${FRONTEND_PORT-3000}"
+    # ports:
+    #   - "${FRONTEND_PORT-3000}:${FRONTEND_PORT-3000}"
     environment:
       - DD_AGENT_HOST=datadog
       - DD_LOGS_INJECTION=true
@@ -106,8 +106,8 @@ services:
       - datadog
       - db
       - redis
-    ports:
-      - ${ADMIN_PORT:-4000}:${ADMIN_PORT:-4000}
+    # ports:
+    #   - ${ADMIN_PORT:-4000}:${ADMIN_PORT:-4000}
     volumes:
       - "/root/rails_database.yml:/app/config/database.yml"
       - "/root/services/backend/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb"

--- a/courses/service-catalog/docker-compose.yml
+++ b/courses/service-catalog/docker-compose.yml
@@ -17,19 +17,19 @@ services:
       - DD_RUNTIME_SECURITY_CONFIG_ENABLED=true
       - DD_RUNTIME_SECURITY_CONFIG_NETWORK_ENABLED=true
       - HOST_ROOT='/host/root'
-    pid: host
+    pid: "host"
     ports:
       - "8126:8126/tcp"
       - "8125:8125/udp"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - /sys/kernel/debug:/sys/kernel/debug
-      - /:/host/root:ro
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
-      - /etc/os-release:/etc/os-release
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "/proc/:/host/proc/:ro"
+      - "/sys/fs/cgroup/:/host/sys/fs/cgroup:ro"
+      - "/sys/kernel/debug:/sys/kernel/debug"
+      - "/:/host/root:ro"
+      - "/etc/passwd:/etc/passwd:ro"
+      - "/etc/group:/etc/group:ro"
+      - "/etc/os-release:/etc/os-release"
     cap_add:
       - SYS_ADMIN
       - SYS_RESOURCE
@@ -72,7 +72,7 @@ services:
     image: public.ecr.aws/x2b9z2t7/storedog/frontend:1.0.8
     command: bash -c "yarn upgrade @datadog/browser-rum && yarn dev"
     volumes:
-      - /root/lab/.env:/storedog-app/site/.env.local
+      - "/root/lab/.env:/storedog-app/site/.env.local"
     ports:
       - "${FRONTEND_PORT-3000}:${FRONTEND_PORT-3000}"
     environment:
@@ -109,8 +109,8 @@ services:
     ports:
       - ${ADMIN_PORT:-4000}:${ADMIN_PORT:-4000}
     volumes:
-      - '/root/rails_database.yml:/app/config/database.yml'
-      - '/root/services/backend/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb'
+      - "/root/rails_database.yml:/app/config/database.yml"
+      - "/root/services/backend/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb"
     environment:
       - REDIS_URL
       - DB_HOST=db
@@ -143,8 +143,8 @@ services:
       - backend
       - datadog
     volumes:
-      - '/root/rails_database.yml:/app/config/database.yml'
-      - '/root/services/worker/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb'
+      - "/root/rails_database.yml:/app/config/database.yml"
+      - "/root/services/worker/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb"
     environment:
       - REDIS_URL
       - DB_HOST=db
@@ -203,8 +203,8 @@ services:
     depends_on:
       - frontend
     volumes:
-      - /root/nginx_default.conf:/etc/nginx/conf.d/default.conf
-      - /root/nginx_status.conf:/etc/nginx/conf.d/status.conf
+      - "/root/nginx_default.conf:/etc/nginx/conf.d/default.conf"
+      - "/root/nginx_status.conf:/etc/nginx/conf.d/status.conf"
     labels:
       com.datadog.tags.env: '${DD_ENV}'
       com.datadog.tags.service: 'store-nginx'
@@ -231,11 +231,11 @@ services:
       com.datadoghq.ad.instances: '[{"host":"%%host%%", "port":5432,"username":"datadog","password":"datadog"}]'
       com.datadoghq.ad.logs: '[{"source": "postgresql", "service": "postgres"}]'
     volumes:
-      - /root/restore.sql:/docker-entrypoint-initdb.d/restore.sql
+      - "/root/restore.sql:/docker-entrypoint-initdb.d/restore.sql"
   redis:
     image: redis:6.2-alpine
     volumes:
-      - '/root/redis:/data'
+      - "/root/redis:/data"
     labels:
       com.datadoghq.tags.env: '${DD_ENV}'
       com.datadoghq.tags.service: 'redis'
@@ -268,8 +268,8 @@ services:
   puppeteer:
     image: buildkite/puppeteer:10.0.0
     volumes:
-      - /root/puppeteer.js:/puppeteer.js
-      - /root/puppeteer.sh:/puppeteer.sh
+      - "/root/puppeteer.js:/puppeteer.js"
+      - "/root/puppeteer.sh:/puppeteer.sh"
     environment:
       - STOREDOG_URL
       - PUPPETEER_TIMEOUT

--- a/courses/service-catalog/docker-compose.yml
+++ b/courses/service-catalog/docker-compose.yml
@@ -103,9 +103,9 @@ services:
     image: public.ecr.aws/x2b9z2t7/storedog/backend:1.0.8
     command: wait-for-it db:5432 -- bundle exec rails s -b 0.0.0.0 -p 4000
     depends_on:
-      - 'db'
-      - 'redis'
-      - 'datadog'
+      - datadog
+      - db
+      - redis
     ports:
       - ${ADMIN_PORT:-4000}:${ADMIN_PORT:-4000}
     volumes:

--- a/courses/service-catalog/docker-compose.yml
+++ b/courses/service-catalog/docker-compose.yml
@@ -169,7 +169,7 @@ services:
       com.datadoghq.tags.version: '1.0.8'
       my.custom.label.team: 'backend'
   advertisements:
-    image: 'public.ecr.aws/x2b9z2t7/storedog/ads:1.0.8'
+    image: public.ecr.aws/x2b9z2t7/storedog/ads:1.0.8
     environment:
       - FLASK_APP=ads.py
       - FLASK_DEBUG=1

--- a/courses/service-catalog/docker-compose.yml
+++ b/courses/service-catalog/docker-compose.yml
@@ -73,8 +73,8 @@ services:
     command: bash -c "yarn upgrade @datadog/browser-rum && yarn dev"
     volumes:
       - "/root/lab/.env:/storedog-app/site/.env.local"
-    # ports:
-    #   - "${FRONTEND_PORT-3000}:${FRONTEND_PORT-3000}"
+    ports:
+      - "${FRONTEND_PORT-3000}:${FRONTEND_PORT-3000}"
     environment:
       - DD_AGENT_HOST=datadog
       - DD_LOGS_INJECTION=true
@@ -106,8 +106,8 @@ services:
       - datadog
       - db
       - redis
-    # ports:
-    #   - ${ADMIN_PORT:-4000}:${ADMIN_PORT:-4000}
+    ports:
+      - ${ADMIN_PORT:-4000}:${ADMIN_PORT:-4000}
     volumes:
       - "/root/rails_database.yml:/app/config/database.yml"
       - "/root/services/backend/config/initializers/datadog-tracer.rb:/app/config/initializers/datadog-tracer.rb"

--- a/courses/service-catalog/docker-compose.yml
+++ b/courses/service-catalog/docker-compose.yml
@@ -201,6 +201,7 @@ services:
     ports:
       - "80:80"
     depends_on:
+      - datadog
       - frontend
     volumes:
       - "/root/nginx_default.conf:/etc/nginx/conf.d/default.conf"


### PR DESCRIPTION
Updated the docker-compose file to match standards from Docker and DD docs.

Note:
The Docker docs show both a more YAML format and the "qual sign" format. In this case, the file matches with DD docs.
Example:
```
    environment:
      - FLASK_APP=ads.py
      - FLASK_DEBUG=1
```
and
```
    labels:
      com.datadog.tags.env: '${DD_ENV}'
      com.datadog.tags.service: 'store-nginx'
```