### PR TITLE
TRAIN-1025: Remove invisible characters that cause yaml error for user

### DIFF
--- a/workshops/dash-observability-pipelines/canonical/vpc-sandbox.yaml
+++ b/workshops/dash-observability-pipelines/canonical/vpc-sandbox.yaml
@@ -38,7 +38,7 @@ transforms:
           .vpc = msg
         }
       }
-​
+
 # transforms:
   # This will allow us to differentiate our downstream steps depending
   # on what parsing succeeded previously, since we don't want non-HTTP
@@ -51,7 +51,7 @@ transforms:
     route:
       http: "exists(.http)"
       vpc: "exists(.vpc)"
-​
+
 # transforms:
   # This step can replace the existing deal_with_useless_http_logs.
   # Anything that would have failed the condition previously is
@@ -64,7 +64,7 @@ transforms:
       - route_log_type.http
     exclude: ".http.status > 200 ?? true"
     rate: 100
-​
+
 # transforms:
   # This will show errors properly categorized in the Log Explorer,
   # instead of always showing up as `INFO`
@@ -79,7 +79,7 @@ transforms:
           .status = "error"
         }
       }
-​
+
 # transforms:
   http_log_metrics:
     type: log_to_metric
@@ -93,7 +93,7 @@ transforms:
         tags:
           status: "{{http.status}}"
           path: "{{http.path}}"
-​
+
 # transforms:
   cardinality_control:
     type: tag_cardinality_limit
@@ -102,7 +102,7 @@ transforms:
     limit_exceeded_action: drop_tag
     mode: probabilistic
     value_limit: 100
-​
+
 # transforms:
   remove_cc:
     type: remap
@@ -128,7 +128,7 @@ transforms:
         tags:
           action: "{{vpc.action}}"
           port: "{{vpc.port}}"
-​
+
   vpc_drop_accepted:
     type: filter
     inputs:
@@ -142,7 +142,7 @@ transforms:
       - remove_cc
     route:
       yes: "exists(.redacted)"
-​
+
   redacted_metrics:
     type: log_to_metric
     inputs:
@@ -152,7 +152,7 @@ transforms:
         field: status
         name: redacted
         namespace: security
-​
+
 # transforms:
   tag_logs:
     type: remap
@@ -163,14 +163,14 @@ transforms:
     source: |-
       # Parse the received `.ddtags` field so we can more easily access the contained tags.
       .ddtags = parse_key_value!(.ddtags, key_value_delimiter: ":", field_delimiter: ",")
-​
+
       # Add some tags so that we can positively identify that data has passed through OP.
       .ddtags.sender = "observability_pipelines"
       .ddtags.op_aggregator = get_hostname!()
-​
+
       # Re-encode Datadog tags in the format the intakes expect.
       .ddtags = encode_key_value(.ddtags, key_value_delimiter: ":", field_delimiter: ",")
-​
+
 # transforms:
   tag_metrics:
     type: remap
@@ -183,7 +183,7 @@ transforms:
       # Add some tags so that we can positively identify that data has passed through OP.
       .tags.sender = "observability_pipelines"
       .tags.op_aggregator = get_hostname!()
-​
+
 sinks:
   datadog_logs:
     type: datadog_logs


### PR DESCRIPTION
There are several invisible characters that lead to a workshop user having several yaml config errors when copying and pasting this reference file into their opw yaml. This PR addresses that.